### PR TITLE
ci: fix error and trigger on all pushes and PRs

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,11 +1,6 @@
 name: Node CI
 
-on:
-  push:
-    branches:
-      - "master"
-    tags-ignore:
-      - "**"
+on: [push, pull_request]
 
 jobs:
   build:
@@ -25,7 +20,7 @@ jobs:
           node-version: "13"
 
       - name: Cache dependencies
-        if: matrix.os != "windows-latest"
+        if: matrix.os != 'windows-latest'
         uses: actions/cache@v1
         with:
           path: ~/.npm


### PR DESCRIPTION
Though there are no CI tests, we can test the workflow itself, and possibly some other problems causing the build to fail.